### PR TITLE
Promotion Event

### DIFF
--- a/resources/js/board/board.js
+++ b/resources/js/board/board.js
@@ -49,7 +49,7 @@ class Board {
 
   // move a piece on the board
   movePiece(move) {
-    const piece = this.getPieceById(move.piece);
+    const piece = move.piece;
     const startSquare = this.getSquare(piece.AN);
     const targetSquare = this.getSquare(move.targetSquare);
 

--- a/resources/js/game/Game.js
+++ b/resources/js/game/Game.js
@@ -88,9 +88,18 @@ class Game {
   makeMove(move) {
     // update the board
     this.board.movePiece(move);
+    const piece = this.board.getPieceById(move.piece);
+
     // if the move if castling, also move the rook
     if (move.moveType === 'k' || move.moveType === 'q') {
       this.board.movePiece(move.rookMove);
+    }
+
+    // promotion event - when pawn gets to 1st (black) or 8th (white) rank, they can promote to another piece
+    if (move.promotion) {
+      const promoteTo = prompt('What would you like to promote to? ');
+      //NEED TO ADD VALIDATION OF PIECE TYPE BEING ENTERED
+      piece.promotePawn(promoteTo);
     }
 
     // look for checks

--- a/resources/js/game/Game.js
+++ b/resources/js/game/Game.js
@@ -254,10 +254,4 @@ class Game {
   }
 }
 
-const gameTest = new Game(pieceSetup);
-
-// test moves
-// e4, d4
-// exd4, Qxd4
-
 module.exports = Game;

--- a/resources/js/game/Game.js
+++ b/resources/js/game/Game.js
@@ -82,6 +82,39 @@ class Game {
     }
   }
 
+  // promotion event when pawn gets to final rank
+  promotionEvent(piece) {
+    const legalPromoteTo = ['q', 'r', 'n', 'b'];
+    let promoteTo;
+
+    // get user input of which piece type they want to promote to
+    do {
+      console.clear();
+      this.printBoard();
+
+      console.log('Promote pawn - which piece would you like to promote to?\nq - queen\nr - rook\nn - knight\nb - bishop\n');
+      promoteTo = prompt('>');
+    } while (!legalPromoteTo.includes(promoteTo));
+
+    // translate input into full piece name
+    switch (promoteTo) {
+      case 'q':
+        promoteTo = 'queen';
+        break
+      case 'r':
+        promoteTo = 'rook';
+        break
+      case 'n':
+        promoteTo = 'knight';
+        break
+      case 'b':
+        promoteTo = 'bishop';
+        break
+    }
+
+    // promote the piece
+    piece.promotePawn(promoteTo);
+  }
 
 
   // make a move by moving the piece, looking whether it leaves opponent in check, printing the board and then updating move number and whose turn it is
@@ -95,11 +128,9 @@ class Game {
       this.board.movePiece(move.rookMove);
     }
 
-    // promotion event - when pawn gets to 1st (black) or 8th (white) rank, they can promote to another piece
+    // run a promotion event if the move permits
     if (move.promotion) {
-      const promoteTo = prompt('What would you like to promote to? ');
-      //NEED TO ADD VALIDATION OF PIECE TYPE BEING ENTERED
-      piece.promotePawn(promoteTo);
+      this.promotionEvent(piece)
     }
 
     // look for checks

--- a/resources/js/game/Game.js
+++ b/resources/js/game/Game.js
@@ -88,7 +88,7 @@ class Game {
   makeMove(move) {
     // update the board
     this.board.movePiece(move);
-    const piece = this.board.getPieceById(move.piece);
+    const piece = move.piece;
 
     // if the move if castling, also move the rook
     if (move.moveType === 'k' || move.moveType === 'q') {

--- a/resources/js/moves/Move.js
+++ b/resources/js/moves/Move.js
@@ -14,7 +14,7 @@ r - rook move during castling
 class Move {
   constructor(moveType, piece, targetSquare, board, canCapture) {
     this.moveType = moveType;
-    this.piece = piece.id;
+    this.piece = piece;
     this.startSquare = piece.AN;
     this.targetSquare = targetSquare;
     this.capture = this.getCapture(targetSquare, board, moveType);
@@ -69,7 +69,7 @@ class Move {
 
   // get the algebraic notation for the move - read the following link for more info: https://en.wikipedia.org/wiki/Algebraic_notation_(chess)#Notation_for_moves
   getMoveAN(piece, targetSquare, board) {
-    const pieceNotation = piece.id[1];
+    const pieceNotation = piece.typeCode;
     if (pieceNotation === 'P') {
       // pawn moves aren't started with the letter 'p'
       return ((this.getCapture(targetSquare, board) ? piece.AN[0] + 'x' : '') + targetSquare)

--- a/resources/js/moves/Move.js
+++ b/resources/js/moves/Move.js
@@ -13,11 +13,12 @@ r - rook move during castling
 
 class Move {
   constructor(moveType, piece, targetSquare, board, canCapture) {
-    this.moveType = moveType; 
+    this.moveType = moveType;
     this.piece = piece.id;
     this.startSquare = piece.AN;
     this.targetSquare = targetSquare;
     this.capture = this.getCapture(targetSquare, board, moveType);
+    this.promotion = this.getPromotion(piece, targetSquare, board)
     this.canCapture = canCapture ? true : false;
     this.targetPiece = this.getTargetPiece(targetSquare, board, moveType);
     this.moveAN = this.getMoveAN(piece, targetSquare, board)
@@ -29,6 +30,17 @@ class Move {
       return true;
     } else {
       return false;
+    }
+  }
+
+  //calculature whether the move is a promotion event
+  getPromotion(piece, targetSquare) {
+    if (piece.type === 'pawn') {
+      if (targetSquare[1] === '8' || targetSquare[1] === '1') {
+        return true;
+      } else {
+        return false;
+      }
     }
   }
 

--- a/resources/js/moves/Move.js
+++ b/resources/js/moves/Move.js
@@ -33,10 +33,10 @@ class Move {
     }
   }
 
-  //calculature whether the move is a promotion event
+  // calculate whether the move is a promotion event - when a pawn gets to the final rank
   getPromotion(piece, targetSquare) {
     if (piece.type === 'pawn') {
-      if (targetSquare[1] === '8' || targetSquare[1] === '1') {
+      if (targetSquare[1] === '1' || targetSquare[1] === '8') {
         return true;
       } else {
         return false;

--- a/resources/js/moves/getLegalMoves.js
+++ b/resources/js/moves/getLegalMoves.js
@@ -170,7 +170,7 @@ const leaveSelfInCheck = (move, board) => {
   boardCopy.setBoard();
 
   // calculate who has the next turn by returning the opposite of whoever is making the move passed in
-  const thisTurn = move.piece[0];
+  const thisTurn = move.piece.color;
   const nextTurn = thisTurn === 'w' ? 'b' : 'w';
 
   // get piece to move's current x and y
@@ -182,7 +182,7 @@ const leaveSelfInCheck = (move, board) => {
   
   // move the piece on the board copy (hasn't moved on the actual board)
   boardCopy.current[y][x].currentPiece = null;
-  boardCopy.current[newY][newX].currentPiece = board.getPieceById(move.piece); 
+  boardCopy.current[newY][newX].currentPiece = move.piece; 
 
   // save the king id (of the colour who is attempting to make the move)
   const kingId = thisTurn == 'b' ? 'bKe8' : 'wKe1'

--- a/resources/js/pieces/ChessPiece.js
+++ b/resources/js/pieces/ChessPiece.js
@@ -44,7 +44,7 @@ const getTypeCode = (type) => {
 class ChessPiece {
   constructor(type, color, AN) {
     this.id = color + getTypeCode(type) + AN;
-    this.src = `./images/pieces/${color}-${type}`
+    this.src = `./images/pieces/${color}-${type}`;
     this.type = type;
     this.typeCode = getTypeCode(type);
     this.value = getValue(type);
@@ -54,35 +54,53 @@ class ChessPiece {
     this.y = ANToXy(AN)[1];
     this.initPos = true;
     this.captured = false;
+    this.promoted = false;
     this.moves = getMoves(type, color)
   }
 
+  // get array of x and y co-ordinates
   get xy() {
     return [this.x, this.y];
   } 
 
+  // set initial position to false if pieces first move
   makeFirstMove() {
     this.initPos = false;
   }
 
+  // reset initial position to true
   resetInitPos() {
     this.initPos = true;
   }
 
+  // move a piece by updating its positional properties
   move(newAN) {
     this.x = ANToXy(newAN)[0];
     this.y = ANToXy(newAN)[1];
     this.AN = newAN;
+    // set initial position to false
     if (this.initPos) {
       this.makeFirstMove();
     }
   }
 
+  // set the captured property of the piece
   setCaptured() {
     this.x = null;
     this.y = null;
     this.AN = null;
     this.captured = true;
+  }
+
+  // update piece properties when being promoted
+  promotePawn(promoteTo) {
+    this.type = promoteTo;
+    this.moves = getMoves(promoteTo, this.color);
+    this.typeCode = getTypeCode(promoteTo);
+    this.value = getValue(promoteTo);
+    this.id += this.typeCode;
+    this.src = `./images/pieces/${this.color}-${this.type}`;
+    this.promoted = true;
   }
 }
 


### PR DESCRIPTION
Add promotion event:
- Move class has added getPromotion function to check if the move is a promotion
- ChessPiece class has added promotePawn function to promote the piece
- Game class has added promotionEvent function that is called if a move is a promotion, requesting user input for what piece they want to promote to. This then calls the ChessPiece.promotePawn function.